### PR TITLE
cut v4.0.0 release w/ link to GoDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [![GoDoc](https://godoc.org/github.com/namedotcom/go/namecom?status.svg)](https://godoc.org/github.com/namedotcom/go/namecom)
+
 # Namecom
 
 Name.com API Go Client.
+
+**GoDoc** on pkg.go: [github.com/namedotcom/go](https://pkg.go.dev/github.com/namedotcom/go)
 
 Documentation for the Name.com v4 API can be found here: https://www.name.com/api-docs

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/namedotcom/go
+module github.com/namedotcom/go/v4
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/namedotcom/go
+
+go 1.14
+
+require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Re: https://github.com/namedotcom/go/issues/3

Still needs to be semver tagged after merge:

```bash
git clone git@github.com:namedotcom/go.git go-namedotcom
pushd go-namedotcom/
git tag v4.0.0
git push --tags
```